### PR TITLE
build.sh: fix for POSIX `sed`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,7 +72,7 @@ then
 	mkdir iso
 fi
 cp Vagrantfile.template Vagrantfile
-sed -i "s/{{VERSION}}/$version/g" Vagrantfile
-sed -i "s/{{OS_VERSION}}/$OS_VERSION/g" Vagrantfile
+sed -i "" -e "s/{{VERSION}}/$version/g" Vagrantfile
+sed -i "" -e "s/{{OS_VERSION}}/$OS_VERSION/g" Vagrantfile
 echo "> Creating vagrant box version $version ..."
 packer build -var "vm_version=$version" "${packerjson}"


### PR DESCRIPTION
currently only works with GNU `sed`.